### PR TITLE
Home Page Data Integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
       ],
       "dependencies": {
         "all": "^0.0.0",
+        "chart.js": "^4.4.6",
+        "react-chartjs-2": "^5.2.0",
         "react-router-dom": "^6.27.0",
         "spotify-web-api-js": "^1.5.2",
         "spotify-web-api-node": "^5.0.2"
@@ -836,6 +838,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1711,6 +1719,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.6.tgz",
+      "integrity": "sha512-8Y406zevUPbbIBA/HRk33khEmQPk5+cxeflWE/2rx1NJsjVWMPw/9mSP9rxHP5eqi6LNoPBVMfZHxbwLSgldYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -4673,6 +4693,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "all": "^0.0.0",
+    "chart.js": "^4.4.6",
+    "react-chartjs-2": "^5.2.0",
     "react-router-dom": "^6.27.0",
     "spotify-web-api-js": "^1.5.2",
     "spotify-web-api-node": "^5.0.2"

--- a/packages/react-frontend/src/components/layout/layout.css
+++ b/packages/react-frontend/src/components/layout/layout.css
@@ -1,9 +1,10 @@
 .page-container {
-    padding-top: 0px;
-    width: 100%;
-    min-height: 100vh;
-  }
-  
-  .page-container.with-navbar {
-    padding-top: 64px; /* navbar (56px) */
-  }
+  padding-top: 0px;
+  width: 100%;
+  min-height: 100vh;
+}
+
+.page-container.with-navbar {
+  padding-top: 64px; /* navbar (64px) */
+  padding-bottom: 96px; /* allow space for the time range selector */
+}

--- a/packages/react-frontend/src/components/visualizations/albumGridImage.jsx
+++ b/packages/react-frontend/src/components/visualizations/albumGridImage.jsx
@@ -17,7 +17,7 @@ const AlbumGridImage = ({ n, time_range }) => {
         });
         const tracks = topTracksData.items;
 
-        // gt unique album image URLs
+        // get unique album image URLs
         const uniqueAlbums = new Map();
 
         tracks.forEach((track) => {

--- a/packages/react-frontend/src/components/visualizations/albumGridImage.jsx
+++ b/packages/react-frontend/src/components/visualizations/albumGridImage.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useSpotifyApi } from "../../SpotifyContext";
+import LoadingSpinner from "../loadingSpinner";
+
+const AlbumGridImage = ({ n, time_range }) => {
+  const canvasRef = useRef(null);
+  const spotifyApi = useSpotifyApi();
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAndDrawAlbums = async () => {
+      try {
+        // fetch top tracks
+        const topTracksData = await spotifyApi.getMyTopTracks({
+          limit: 50, // fetch enough tracks to ensure enough unique albums
+          time_range: time_range,
+        });
+        const tracks = topTracksData.items;
+
+        // gt unique album image URLs
+        const uniqueAlbums = new Map();
+
+        tracks.forEach((track) => {
+          const albumId = track.album.id;
+          if (!uniqueAlbums.has(albumId)) {
+            const imageUrl = track.album.images[0]?.url;
+            if (imageUrl) {
+              uniqueAlbums.set(albumId, imageUrl);
+            }
+          }
+        });
+
+        // convert the Map values to an array of image URLs
+        const albumImages = Array.from(uniqueAlbums.values());
+
+        // limit to n^2 images
+        const limitedAlbumImages = albumImages.slice(0, n * n);
+
+        // load images
+        const loadedImages = await Promise.all(
+          limitedAlbumImages.map((src) => loadImage(src))
+        );
+
+        // put images on canvas
+        drawImagesOnCanvas(loadedImages);
+        setIsLoading(false);
+      } catch (error) {
+        console.error("Error fetching top albums:", error);
+      }
+    };
+
+    fetchAndDrawAlbums();
+  }, [spotifyApi, n, time_range]);
+
+  const loadImage = (src) => {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.crossOrigin = "Anonymous";
+      img.onload = () => resolve(img);
+      img.onerror = (err) => reject(err);
+      img.src = src;
+    });
+  };
+
+  const drawImagesOnCanvas = (images) => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      console.error("Canvas not found");
+      return;
+    }
+    const context = canvas.getContext("2d");
+
+    const gridSize = n;
+    const imageSize = 100;
+    const canvasSize = gridSize * imageSize;
+
+    canvas.width = canvasSize;
+    canvas.height = canvasSize;
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+
+    images.forEach((img, index) => {
+      const x = (index % gridSize) * imageSize;
+      const y = Math.floor(index / gridSize) * imageSize;
+      context.drawImage(img, x, y, imageSize, imageSize);
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative group">
+        <canvas
+          ref={canvasRef}
+          className="mb-4 rounded-3xl transition-transform transform group-hover:scale-105 group-hover:shadow-2xl"
+        ></canvas>
+
+        {isLoading && (
+          <div className="absolute rounded-3xl inset-0 flex items-center justify-center bg-zinc-900 bg-opacity-75">
+            <p className="text-white">Loading album cover grid...</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AlbumGridImage;

--- a/packages/react-frontend/src/components/visualizations/genreBarGraph.jsx
+++ b/packages/react-frontend/src/components/visualizations/genreBarGraph.jsx
@@ -20,6 +20,8 @@ ChartJS.register(
   Legend
 );
 
+ChartJS.defaults.color = "#FFFFFF";
+
 const GenreBarGraph = ({ genreData }) => {
   // Prepare data for the chart
   const genreLabels = genreData.map((genre) => genre[0]);

--- a/packages/react-frontend/src/components/visualizations/genreBarGraph.jsx
+++ b/packages/react-frontend/src/components/visualizations/genreBarGraph.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+// Register Chart.js components, necessary to avoid errors
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+const GenreBarGraph = ({ genreData }) => {
+  // Prepare data for the chart
+  const genreLabels = genreData.map((genre) => genre[0]);
+  const genreCounts = genreData.map((genre) => genre[1]);
+
+  const data = {
+    labels: genreLabels,
+    datasets: [
+      {
+        label: "Genre Frequency of Artists Listened To",
+        data: genreCounts,
+        backgroundColor: "rgba(29, 185, 84, 0.6)", // Spotify green color with opacity
+        borderColor: "rgba(29, 185, 84, 1)", // Spotify green color
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const options = {
+    scales: {
+      y: {
+        beginAtZero: true,
+      },
+    },
+  };
+
+  return <Bar data={data} options={options} />;
+};
+
+export default GenreBarGraph;

--- a/packages/react-frontend/src/pages/artists.jsx
+++ b/packages/react-frontend/src/pages/artists.jsx
@@ -1,76 +1,79 @@
-import '../index.css'
-import React, {useState, useEffect} from 'react'
-import { useSpotifyApi } from '../SpotifyContext'; 
-import { getTopNArtists } from '../utils/getTopUtils';
-import ArtistPreview from '../components/artistPreview/artistPreview';
-import LoadingSpinner from '../components/loadingSpinner';
+import "../index.css";
+import React, { useState, useEffect } from "react";
+import { useSpotifyApi } from "../SpotifyContext";
+import { getTopNArtists } from "../utils/getTopUtils";
+import ArtistPreview from "../components/artistPreview/artistPreview";
+import LoadingSpinner from "../components/loadingSpinner";
 
-function ArtistPage({time_range}) {
-    const spotifyApi = useSpotifyApi();
-    const [artists1month, setArtists1Month] = useState([]);
-    const [artists6month, setArtists6Month] = useState([]);
-    const [artistsLifetime, setArtistsLifetime] = useState([]);
-    const [topArtists, setTopArtists] = useState([]);
-    const [isLoading, setIsLoading] = useState(true);
+function ArtistPage({ time_range }) {
+  const spotifyApi = useSpotifyApi();
+  const [artists1month, setArtists1Month] = useState([]);
+  const [artists6month, setArtists6Month] = useState([]);
+  const [artistsLifetime, setArtistsLifetime] = useState([]);
+  const [topArtists, setTopArtists] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
-    // When the page loads, get the top 25 artists for each time range
-    useEffect(() => {
-        const fetchArtists = async () => {
-            try {
+  // When the page loads, get the top 25 artists for each time range
+  useEffect(() => {
+    const fetchArtists = async () => {
+      try {
+        setArtists1Month(await getTopNArtists(spotifyApi, 25, "short_term"));
+        setArtists6Month(await getTopNArtists(spotifyApi, 25, "medium_term"));
+        setArtistsLifetime(await getTopNArtists(spotifyApi, 25, "long_term"));
+      } catch (err) {
+        console.error("Error fetching artists:", err);
+      }
+    };
 
-                setArtists1Month(await getTopNArtists(spotifyApi, 25, "short_term"));
-                setArtists6Month(await getTopNArtists(spotifyApi, 25, "medium_term"));
-                setArtistsLifetime(await getTopNArtists(spotifyApi, 25, "long_term"));
-            } catch (err) {
-                console.error('Error fetching artists:', err);
-            }
-        };
+    fetchArtists();
+    console.log(topArtists[0]);
+  }, [spotifyApi]);
 
-        fetchArtists();
-        console.log(topArtists[0])
-    }, [spotifyApi]);
-
-    // When timerange changes, update the currently displayed list
-    useEffect(() => {
-        if (time_range === "short_term") {
-            setTopArtists(artists1month);
-        } else if (time_range === "medium_term") {
-            setTopArtists(artists6month);
-        } else if (time_range === "long_term") {
-            setTopArtists(artistsLifetime);
-        }
-        setIsLoading(false);
-    }, [spotifyApi, time_range, artists1month, artists6month, artistsLifetime]);
-
-    if (isLoading) {
-        return (<LoadingSpinner/>)
+  // When timerange changes, update the currently displayed list
+  useEffect(() => {
+    if (time_range === "short_term") {
+      setTopArtists(artists1month);
+    } else if (time_range === "medium_term") {
+      setTopArtists(artists6month);
+    } else if (time_range === "long_term") {
+      setTopArtists(artistsLifetime);
     }
-    
+    setIsLoading(false);
+  }, [spotifyApi, time_range, artists1month, artists6month, artistsLifetime]);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
   return (
-    <div className='flex flex-col items-center min-h-screen text-white bg-gradient-to-br from-zinc-800 to-zinc-950'>
-        {/* Title */}
-        <p className='text-center font-bold mb-4 mt-4 text-4xl'>Your Top Artists</p>
-        {/* List of Artist Previews */}
-        <div className='space-y-4 mb-4'>
-            {topArtists.map((a, i) => <ArtistPreview artist={a} index={i + 1}/>)}
-        </div>
-        {/* Buttons to see more/all */}
-        <div className="flex space-x-4 mb-20">
-            <button
-                className="bg-zinc-800 text-white font-semibold py-3 px-8 rounded-full shadow-lg transform transition-transform hover:scale-105 active:scale-95 hover:shadow-xl focus:outline-none hover:text-[#00FF7F] w-36"
-                style={{ border: 'none' }}
-            >
-                See More
-            </button>
-            <button
-                className="bg-zinc-800 text-white font-semibold py-3 px-8 rounded-full shadow-lg transform transition-transform hover:scale-105 active:scale-95 hover:shadow-xl focus:outline-none hover:text-[#00FF7F] w-36"
-                style={{ border: 'none' }}
-            >
-                See All
-            </button>
-        </div>
+    <div className="flex flex-col items-center min-h-screen text-white bg-gradient-to-br from-zinc-800 to-zinc-950">
+      {/* Title */}
+      <p className="text-center font-bold mb-4 mt-4 text-4xl">
+        Your Top Artists
+      </p>
+      {/* List of Artist Previews */}
+      <div className="space-y-4 mb-4">
+        {topArtists.map((a, i) => (
+          <ArtistPreview artist={a} index={i + 1} />
+        ))}
+      </div>
+      {/* Buttons to see more/all */}
+      <div className="flex space-x-4 mb-20">
+        <button
+          className="bg-zinc-800 text-white font-semibold py-3 px-8 rounded-full shadow-lg transform transition-transform hover:scale-105 active:scale-95 hover:shadow-xl focus:outline-none hover:text-[#00FF7F] w-36"
+          style={{ border: "none" }}
+        >
+          See More
+        </button>
+        <button
+          className="bg-zinc-800 text-white font-semibold py-3 px-8 rounded-full shadow-lg transform transition-transform hover:scale-105 active:scale-95 hover:shadow-xl focus:outline-none hover:text-[#00FF7F] w-36"
+          style={{ border: "none" }}
+        >
+          See All
+        </button>
+      </div>
     </div>
-  )
+  );
 }
 
 export default ArtistPage;

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -2,6 +2,7 @@ import "../index.css";
 import React, { useState, useEffect } from "react";
 import { useSpotifyApi } from "../SpotifyContext";
 import { useLocation } from "react-router-dom";
+import LoadingSpinner from "../components/loadingSpinner";
 import {
   getTopNArtists,
   getTopNTracks,
@@ -24,6 +25,7 @@ const getTokenFromUrl = () => {
 function Home({ setLoggedIn, time_range }) {
   const spotifyApi = useSpotifyApi();
   const [spotifyToken, setSpotifyToken] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
   // Artists
   const [topArtists1Month, setTopArtists1Month] = useState([]);
   const [topArtists6Month, setTopArtists6Month] = useState([]);
@@ -108,6 +110,7 @@ function Home({ setLoggedIn, time_range }) {
 
       // Initialize the current selections
       updateCurrentData();
+      setIsLoading(false);
     } catch (error) {
       console.error("Error fetching top data:", error);
     }
@@ -132,6 +135,10 @@ function Home({ setLoggedIn, time_range }) {
       setTopAlbumsCur(topAlbumsLifetime);
     }
   };
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
 
   return (
     <div className="bg-gradient-to-br from-zinc-800 to-zinc-950 text-white">

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -5,6 +5,7 @@ import { useSpotifyApi } from "../SpotifyContext";
 import LoadingSpinner from "../components/loadingSpinner";
 import GenreBarGraph from "../components/visualizations/genreBarGraph";
 import { getNGenreFrequencies } from "../utils/getGenreFrequencies";
+import AlbumGridImage from "../components/visualizations/albumGridImage";
 import {
   getTopNArtists,
   getTopNTracks,
@@ -30,7 +31,6 @@ function Home({ setLoggedIn, time_range }) {
   const [username, setUsername] = useState("username");
   const [profilePicture, setProfilePicture] = useState("");
   const [isLoading, setIsLoading] = useState(true);
-
   // Artists
   const [topArtists1Month, setTopArtists1Month] = useState([]);
   const [topArtists6Month, setTopArtists6Month] = useState([]);
@@ -56,30 +56,6 @@ function Home({ setLoggedIn, time_range }) {
   const [topArtistsCur, setTopArtistsCur] = useState([]);
   const [topTracksCur, setTopTracksCur] = useState([]);
   const [topAlbumsCur, setTopAlbumsCur] = useState([]);
-
-  const genreLabels = genreDataCur.map((genre) => genre[0]);
-  const genreCounts = genreDataCur.map((genre) => genre[1]);
-
-  const data = {
-    labels: genreLabels,
-    datasets: [
-      {
-        label: "Genre Frequency",
-        data: genreCounts,
-        backgroundColor: "rgba(29, 185, 84, 0.6)", // Spotify green color with opacity
-        borderColor: "rgba(29, 185, 84, 1)", // Spotify green color
-        borderWidth: 1,
-      },
-    ],
-  };
-
-  const options = {
-    scales: {
-      y: {
-        beginAtZero: true,
-      },
-    },
-  };
 
   // when this page is first loaded, we get the user parameters from the URL
   useEffect(() => {
@@ -207,19 +183,22 @@ function Home({ setLoggedIn, time_range }) {
       {/* Intro Section */}
       <section className="flex justify-center items-center py-8 px-8">
         <div className="flex items-center space-x-8">
-          <div>
+          <div className="ml-28">
             <h2 className="text-4xl font-bold mb-2">Your Music Insights</h2>
             <p className="text-gray-400">
               Explore your top artists, tracks, and more.
             </p>
           </div>
-          <div className="w-64 h-64 bg-gray-700 rounded-lg"></div>
+          <div className="scale-75">
+            <AlbumGridImage n={5} time_range={time_range} />
+          </div>
         </div>
       </section>
 
       {/* User Info Section */}
       <section className="flex justify-center bg-zinc-800 py-6 px-8">
-        <div className="flex bg-gradient-to-br from-zinc-700 rounded-lg shadow-2xl p-4">
+        <div className="flex bg-gradient-to-br from-zinc-700 rounded-lg shadow-xl p-4 scale-105">
+          {" "}
           {profilePicture ? (
             <img
               src={profilePicture}
@@ -241,12 +220,13 @@ function Home({ setLoggedIn, time_range }) {
 
       {/* Top Artists and Tracks Section */}
       <section className="py-10 px-8">
-        <h2 className="text-3xl font-bold text-center mb-8">
+        <h2 className="text-3xl font-bold text-center mb-4">
           Top Artists and Tracks
         </h2>
+        <hr className="mx-auto w-full max-w-3xl border-t border-gray-600 mb-8" />
         <div className="flex justify-around">
           {/* Top Artists List */}
-          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4">
+          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4 transition-transform duration-300 hover:scale-105 hover:shadow-3xl">
             <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
               <h3 className="text-xl font-semibold">Top 5 Artists</h3>
             </div>
@@ -266,7 +246,7 @@ function Home({ setLoggedIn, time_range }) {
           </div>
 
           {/* Top Tracks List */}
-          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4">
+          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4 transition-transform duration-300 hover:scale-105 hover:shadow-3xl">
             <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
               <h3 className="text-xl font-semibold">Top 5 Tracks</h3>
             </div>
@@ -286,7 +266,7 @@ function Home({ setLoggedIn, time_range }) {
           </div>
 
           {/* Top Albums List */}
-          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4">
+          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4 transition-transform duration-300 hover:scale-105 hover:shadow-3xl">
             <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
               <h3 className="text-xl font-semibold">Top 5 Albums</h3>
             </div>
@@ -309,11 +289,11 @@ function Home({ setLoggedIn, time_range }) {
 
       {/* Genre Section */}
       <section className="flex justify-center bg-zinc-800 py-6 px-8">
-        <hr></hr>
         <div className="w-full max-w-3xl">
           <h2 className="text-3xl font-bold text-center mb-4">
             Genre Listening Trends
           </h2>
+          <hr className="w-full mx-auto max-w-lg border-t border-gray-600 mb-8" />
           <GenreBarGraph genreData={genreDataCur} />
         </div>
       </section>

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -228,7 +228,7 @@ function Home({ setLoggedIn, time_range }) {
           {/* Top Artists List */}
           <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4 transition-transform duration-300 hover:scale-105 hover:shadow-3xl">
             <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
-              <h3 className="text-xl font-semibold">Top 5 Artists</h3>
+              <h3 className="text-xl font-semibold">Top Artists</h3>
             </div>
             <ol className="space-y-2 text-gray-300 mb-4 px-2">
               {topArtistsCur.slice(0, 5).map((artist, index) => (
@@ -248,7 +248,7 @@ function Home({ setLoggedIn, time_range }) {
           {/* Top Tracks List */}
           <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4 transition-transform duration-300 hover:scale-105 hover:shadow-3xl">
             <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
-              <h3 className="text-xl font-semibold">Top 5 Tracks</h3>
+              <h3 className="text-xl font-semibold">Top Tracks</h3>
             </div>
             <ol className="space-y-2 text-gray-300 mb-4 px-2">
               {topTracksCur.slice(0, 5).map((track, index) => (
@@ -268,7 +268,7 @@ function Home({ setLoggedIn, time_range }) {
           {/* Top Albums List */}
           <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4 transition-transform duration-300 hover:scale-105 hover:shadow-3xl">
             <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
-              <h3 className="text-xl font-semibold">Top 5 Albums</h3>
+              <h3 className="text-xl font-semibold">Top Albums</h3>
             </div>
             <ol className="space-y-2 text-gray-300 mb-4 px-2">
               {topAlbumsCur.slice(0, 5).map((album, index) => (

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { useSpotifyApi } from "../SpotifyContext";
 import LoadingSpinner from "../components/loadingSpinner";
 import GenreBarGraph from "../components/visualizations/genreBarGraph";
+import { getNGenreFrequencies } from "../utils/getGenreFrequencies";
 import {
   getTopNArtists,
   getTopNTracks,

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -1,5 +1,6 @@
 import "../index.css";
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { useSpotifyApi } from "../SpotifyContext";
 import { useLocation } from "react-router-dom";
 import LoadingSpinner from "../components/loadingSpinner";
@@ -175,38 +176,56 @@ function Home({ setLoggedIn, time_range }) {
         <div className="flex justify-around">
           {/* Top Artists List */}
           <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
-            <h3 className="text-xl font-semibold mb-4">Top Artists</h3>
-            <ol className="space-y-2 text-gray-300">
+            <h3 className="text-xl font-semibold mb-4">Top 5 Artists</h3>
+            <ol className="space-y-2 text-gray-300 mb-4">
               {topArtistsCur.slice(0, 5).map((artist, index) => (
                 <li key={artist.id}>
                   {index + 1}. {artist.name}
                 </li>
               ))}
             </ol>
+            <Link
+              to="/artists"
+              className="bg-zinc-900 text-white py-2 px-4 rounded hover:bg-[#1db954] hover:text-white transition duration-200"
+            >
+              View Details
+            </Link>
           </div>
 
           {/* Top Tracks List */}
           <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
-            <h3 className="text-xl font-semibold mb-4">Top Tracks</h3>
-            <ol className="space-y-2 text-gray-300">
+            <h3 className="text-xl font-semibold mb-4">Top 5 Tracks</h3>
+            <ol className="space-y-2 text-gray-300 mb-4">
               {topTracksCur.slice(0, 5).map((track, index) => (
                 <li key={track.id}>
                   {index + 1}. {track.name}
                 </li>
               ))}
             </ol>
+            <Link
+              to="/tracks"
+              className="bg-zinc-900 text-white py-2 px-4 rounded hover:bg-[#1db954] hover:text-white transition duration-200"
+            >
+              View Details
+            </Link>
           </div>
 
           {/* Top Albums List */}
           <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
-            <h3 className="text-xl font-semibold mb-4">Top Albums</h3>
-            <ol className="space-y-2 text-gray-300">
+            <h3 className="text-xl font-semibold mb-4">Top 5 Albums</h3>
+            <ol className="space-y-2 text-gray-300 mb-4">
               {topAlbumsCur.slice(0, 5).map((album, index) => (
                 <li key={album.id}>
                   {index + 1}. {album.name}
                 </li>
               ))}
             </ol>
+            <Link
+              to="/albums"
+              className="bg-zinc-900 text-white py-2 px-4 rounded hover:bg-[#1db954] hover:text-white transition duration-200"
+            >
+              View Details
+            </Link>
           </div>
         </div>
       </section>

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -175,9 +175,11 @@ function Home({ setLoggedIn, time_range }) {
         </h2>
         <div className="flex justify-around">
           {/* Top Artists List */}
-          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
-            <h3 className="text-xl font-semibold mb-4">Top 5 Artists</h3>
-            <ol className="space-y-2 text-gray-300 mb-4">
+          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4">
+            <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
+              <h3 className="text-xl font-semibold">Top 5 Artists</h3>
+            </div>
+            <ol className="space-y-2 text-gray-300 mb-4 px-2">
               {topArtistsCur.slice(0, 5).map((artist, index) => (
                 <li key={artist.id}>
                   {index + 1}. {artist.name}
@@ -186,16 +188,18 @@ function Home({ setLoggedIn, time_range }) {
             </ol>
             <Link
               to="/artists"
-              className="bg-zinc-900 text-white py-2 px-4 rounded hover:bg-[#1db954] hover:text-white transition duration-200"
+              className="bg-zinc-900 text-white py-2 px-4 rounded border-2 border-zinc-800 hover:border-[#1db954] hover:bg-[#1db954] hover:text-white transition duration-200"
             >
               View Details
             </Link>
           </div>
 
           {/* Top Tracks List */}
-          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
-            <h3 className="text-xl font-semibold mb-4">Top 5 Tracks</h3>
-            <ol className="space-y-2 text-gray-300 mb-4">
+          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4">
+            <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
+              <h3 className="text-xl font-semibold">Top 5 Tracks</h3>
+            </div>
+            <ol className="space-y-2 text-gray-300 mb-4 px-2">
               {topTracksCur.slice(0, 5).map((track, index) => (
                 <li key={track.id}>
                   {index + 1}. {track.name}
@@ -204,16 +208,18 @@ function Home({ setLoggedIn, time_range }) {
             </ol>
             <Link
               to="/tracks"
-              className="bg-zinc-900 text-white py-2 px-4 rounded hover:bg-[#1db954] hover:text-white transition duration-200"
+              className="bg-zinc-900 text-white py-2 px-4 rounded border-2 border-zinc-800 hover:border-[#1db954] hover:bg-[#1db954] hover:text-white transition duration-200"
             >
               View Details
             </Link>
           </div>
 
           {/* Top Albums List */}
-          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
-            <h3 className="text-xl font-semibold mb-4">Top 5 Albums</h3>
-            <ol className="space-y-2 text-gray-300 mb-4">
+          <div className="bg-zinc-800 bg-opacity-50 rounded-lg shadow-md w-1/2 mx-10 pb-4">
+            <div className="w-full mb-4 h-12 bg-[#1db954] text-white flex items-center justify-center rounded-t-lg">
+              <h3 className="text-xl font-semibold">Top 5 Albums</h3>
+            </div>
+            <ol className="space-y-2 text-gray-300 mb-4 px-2">
               {topAlbumsCur.slice(0, 5).map((album, index) => (
                 <li key={album.id}>
                   {index + 1}. {album.name}
@@ -222,7 +228,7 @@ function Home({ setLoggedIn, time_range }) {
             </ol>
             <Link
               to="/albums"
-              className="bg-zinc-900 text-white py-2 px-4 rounded hover:bg-[#1db954] hover:text-white transition duration-200"
+              className="bg-zinc-900 text-white py-2 px-4 rounded border-2 border-zinc-800 hover:border-[#1db954] hover:bg-[#1db954] hover:text-white transition duration-200"
             >
               View Details
             </Link>

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -2,7 +2,6 @@ import "../index.css";
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useSpotifyApi } from "../SpotifyContext";
-import { useLocation } from "react-router-dom";
 import LoadingSpinner from "../components/loadingSpinner";
 import {
   getTopNArtists,
@@ -26,7 +25,10 @@ const getTokenFromUrl = () => {
 function Home({ setLoggedIn, time_range }) {
   const spotifyApi = useSpotifyApi();
   const [spotifyToken, setSpotifyToken] = useState("");
+  const [username, setUsername] = useState("username");
+  const [profilePicture, setProfilePicture] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+
   // Artists
   const [topArtists1Month, setTopArtists1Month] = useState([]);
   const [topArtists6Month, setTopArtists6Month] = useState([]);
@@ -62,11 +64,17 @@ function Home({ setLoggedIn, time_range }) {
       setLoggedIn(true);
       console.log("Current Access Token:", spotifyApi.getAccessToken());
     }
-  }, [spotifyApi]);
+  }, [spotifyApi, setLoggedIn]);
 
   useEffect(() => {
     if (spotifyApi.getAccessToken()) {
       fetchAllTopData();
+
+      // Get the user's name and profile picture
+      spotifyApi.getMe().then((data) => {
+        setUsername(data.display_name);
+        setProfilePicture(data.images?.[0]?.url || "");
+      });
     }
   }, [spotifyApi]);
 
@@ -158,13 +166,23 @@ function Home({ setLoggedIn, time_range }) {
 
       {/* User Info Section */}
       <section className="flex justify-center bg-zinc-800 py-6 px-8">
-        <div className="w-16 h-16 bg-gray-600 rounded-full mr-4"></div>{" "}
-        {/* pfp placeholder */}
-        <div className="text-left mt-2">
-          <h3 className="text-lg font-semibold">usernameplaceholder123</h3>
-          <p className="text-gray-300">
-            Your stats are based on historical data from Spotify.
-          </p>
+        <div className="flex bg-gradient-to-br from-zinc-700 rounded-lg shadow-2xl p-4">
+          {profilePicture ? (
+            <img
+              src={profilePicture}
+              alt="User Profile Picture"
+              className="w-16 h-16 text-lg rounded-full mr-4"
+            />
+          ) : (
+            // placeholder if pfp could not be retrieved
+            <div className="w-16 h-16 bg-gray-600 rounded-full mr-4"></div>
+          )}
+          <div className="text-left mt-2">
+            <h3 className="text-lg font-semibold">{username}</h3>
+            <p className="text-gray-300 text-sm">
+              Your stats are based on historical data from Spotify.
+            </p>
+          </div>
         </div>
       </section>
 

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -1,31 +1,50 @@
-import '../index.css';
-import React, { useState, useEffect } from 'react';
-import { useSpotifyApi } from '../SpotifyContext'; 
-import { useLocation } from 'react-router-dom';
+import "../index.css";
+import React, { useState, useEffect } from "react";
+import { useSpotifyApi } from "../SpotifyContext";
+import { useLocation } from "react-router-dom";
+import {
+  getTopNArtists,
+  getTopNTracks,
+  getTopNAlbums,
+} from "../utils/getTopUtils.js";
 
 // When the user logs in their credentials go to the url
 // This gets their credentials
 const getTokenFromUrl = () => {
-  return window.location.hash.substring(1).split('&').reduce((initial, item) => {
-    let parts = item.split('=');
-    initial[parts[0]] = decodeURIComponent(parts[1]);
-    return initial;
-  }, {});
+  return window.location.hash
+    .substring(1)
+    .split("&")
+    .reduce((initial, item) => {
+      let parts = item.split("=");
+      initial[parts[0]] = decodeURIComponent(parts[1]);
+      return initial;
+    }, {});
 };
 
 function Home({ setLoggedIn, time_range }) {
   const spotifyApi = useSpotifyApi();
   const [spotifyToken, setSpotifyToken] = useState("");
+  // Artists
   const [topArtists1Month, setTopArtists1Month] = useState([]);
   const [topArtists6Month, setTopArtists6Month] = useState([]);
   const [topArtistsLifetime, setTopArtistsLifetime] = useState([]);
+
+  // Tracks
   const [topTracks1Month, setTopTracks1Month] = useState([]);
   const [topTracks6Month, setTopTracks6Month] = useState([]);
   const [topTracksLifetime, setTopTracksLifetime] = useState([]);
+
+  // Albums
+  const [topAlbums1Month, setTopAlbums1Month] = useState([]);
+  const [topAlbums6Month, setTopAlbums6Month] = useState([]);
+  const [topAlbumsLifetime, setTopAlbumsLifetime] = useState([]);
+
+  // Current selections based on time_range
   const [topArtistsCur, setTopArtistsCur] = useState([]);
   const [topTracksCur, setTopTracksCur] = useState([]);
+  const [topAlbumsCur, setTopAlbumsCur] = useState([]);
 
-  // when this page is first loaded, we get the user parameters from the URL 
+  // when this page is first loaded, we get the user parameters from the URL
   useEffect(() => {
     const spotifyToken = getTokenFromUrl().access_token;
     // This removes the users credentials from the URL, making it cleaner
@@ -35,76 +54,83 @@ function Home({ setLoggedIn, time_range }) {
     if (spotifyToken) {
       setSpotifyToken(spotifyToken);
 
-      // Give the token to the api 
+      // Give the token to the api
       spotifyApi.setAccessToken(spotifyToken);
       setLoggedIn(true);
       console.log("Current Access Token:", spotifyApi.getAccessToken());
     }
   }, [spotifyApi]);
 
-  // Preload all the data
   useEffect(() => {
-    getUsersTopArtists("short_term");
-    getUsersTopArtists("medium_term");
-    getUsersTopArtists("long_term");
+    if (spotifyApi.getAccessToken()) {
+      fetchAllTopData();
+    }
+  }, [spotifyApi]);
 
-    getUsersTopTracks("short_term");
-    getUsersTopTracks("medium_term");
-    getUsersTopTracks("long_term");
-  }, [useLocation()]);
+  const fetchAllTopData = async () => {
+    try {
+      // Fetch all short term data
+      const [artists1Month, tracks1Month] = await Promise.all([
+        getTopNArtists(spotifyApi, 50, "short_term"),
+        getTopNTracks(spotifyApi, 50, "short_term"),
+      ]);
+      const albums1Month = await getTopNAlbums(spotifyApi, 50, tracks1Month);
 
-  // When `time_range` changes, update the `topArtistsCur` and `topTracksCur` accordingly
+      setTopArtists1Month(artists1Month);
+      setTopTracks1Month(tracks1Month);
+      setTopAlbums1Month(albums1Month);
+
+      // Fetch all medium term data
+      const [artists6Month, tracks6Month] = await Promise.all([
+        getTopNArtists(spotifyApi, 50, "medium_term"),
+        getTopNTracks(spotifyApi, 50, "medium_term"),
+      ]);
+      const albums6Month = await getTopNAlbums(spotifyApi, 50, tracks6Month);
+
+      setTopArtists6Month(artists6Month);
+      setTopTracks6Month(tracks6Month);
+      setTopAlbums6Month(albums6Month);
+
+      // Fetch all long term data
+      const [artistsLifetime, tracksLifetime] = await Promise.all([
+        getTopNArtists(spotifyApi, 50, "long_term"),
+        getTopNTracks(spotifyApi, 50, "long_term"),
+      ]);
+      const albumsLifetime = await getTopNAlbums(
+        spotifyApi,
+        50,
+        tracksLifetime
+      );
+
+      setTopArtistsLifetime(artistsLifetime);
+      setTopTracksLifetime(tracksLifetime);
+      setTopAlbumsLifetime(albumsLifetime);
+
+      // Initialize the current selections
+      updateCurrentData();
+    } catch (error) {
+      console.error("Error fetching top data:", error);
+    }
+  };
+
   useEffect(() => {
+    updateCurrentData();
+  }, [time_range, topArtists1Month, topArtists6Month, topArtistsLifetime]);
+
+  const updateCurrentData = () => {
     if (time_range === "short_term") {
       setTopArtistsCur(topArtists1Month);
       setTopTracksCur(topTracks1Month);
+      setTopAlbumsCur(topAlbums1Month);
     } else if (time_range === "medium_term") {
       setTopArtistsCur(topArtists6Month);
       setTopTracksCur(topTracks6Month);
+      setTopAlbumsCur(topAlbums6Month);
     } else if (time_range === "long_term") {
       setTopArtistsCur(topArtistsLifetime);
       setTopTracksCur(topTracksLifetime);
+      setTopAlbumsCur(topAlbumsLifetime);
     }
-  }, [time_range, topArtists1Month, topArtists6Month, topArtistsLifetime, topTracks1Month, topTracks6Month, topTracksLifetime, useLocation()]);
-
-  // Fetches the user's top artists based on time range
-  const getUsersTopArtists = (time_range) => {
-    spotifyApi.getMyTopArtists({ time_range: time_range, limit: 50})
-      .then((response) => {
-        console.log(response);
-        const artistNames = response.items.map((artist) => artist.name);
-        // Update the state with fetched artist names based on the time range
-        if (time_range === 'short_term') {
-          setTopArtists1Month(artistNames);
-        } else if (time_range === 'medium_term') {
-          setTopArtists6Month(artistNames);
-        } else if (time_range === 'long_term') {
-          setTopArtistsLifetime(artistNames);
-        }
-      })
-      .catch((err) => {
-        console.error('Error fetching top artists:', err);
-      });
-  };
-
-  // Fetches the user's top tracks based on time range
-  const getUsersTopTracks = (time_range) => {
-    spotifyApi.getMyTopTracks({ time_range: time_range, limit: 50})
-      .then((response) => {
-        console.log(response);
-        const trackNames = response.items.map((track) => track.name);
-        // Update the state with fetched track names based on the time range
-        if (time_range === 'short_term') {
-          setTopTracks1Month(trackNames);
-        } else if (time_range === 'medium_term') {
-          setTopTracks6Month(trackNames);
-        } else if (time_range === 'long_term') {
-          setTopTracksLifetime(trackNames);
-        }
-      })
-      .catch((err) => {
-        console.error('Error fetching top tracks:', err);
-      });
   };
 
   return (
@@ -114,49 +140,76 @@ function Home({ setLoggedIn, time_range }) {
         <div className="flex items-center space-x-8">
           <div>
             <h2 className="text-4xl font-bold mb-2">Your Music Insights</h2>
-            <p className="text-gray-400">Explore your top artists, tracks, and more.</p>
+            <p className="text-gray-400">
+              Explore your top artists, tracks, and more.
+            </p>
           </div>
           <div className="w-64 h-64 bg-gray-700 rounded-lg"></div>
         </div>
       </section>
-  
+
       {/* User Info Section */}
       <section className="flex justify-center bg-zinc-800 py-6 px-8">
-        <div className="w-16 h-16 bg-gray-600 rounded-full mr-4"></div> {/* pfp placeholder */}
+        <div className="w-16 h-16 bg-gray-600 rounded-full mr-4"></div>{" "}
+        {/* pfp placeholder */}
         <div className="text-left mt-2">
           <h3 className="text-lg font-semibold">usernameplaceholder123</h3>
-          <p className="text-gray-300">Your stats are based on historical data from Spotify.</p>
+          <p className="text-gray-300">
+            Your stats are based on historical data from Spotify.
+          </p>
         </div>
       </section>
-  
+
       {/* Top Artists and Tracks Section */}
       <section className="py-10 px-8">
-        <h2 className="text-3xl font-bold text-center mb-8">Top Artists and Tracks</h2>
+        <h2 className="text-3xl font-bold text-center mb-8">
+          Top Artists and Tracks
+        </h2>
         <div className="flex justify-around">
           {/* Top Artists List */}
-          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-4">
+          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
             <h3 className="text-xl font-semibold mb-4">Top Artists</h3>
             <ol className="space-y-2 text-gray-300">
-              <li>1. Artist 1</li>
-              <li>2. Artist 2</li>
-              <li>3. Artist 3</li>
-              <li>4. Artist 4</li>
-              <li>5. Artist 5</li>
+              {topArtistsCur.slice(0, 5).map((artist, index) => (
+                <li key={artist.id}>
+                  {index + 1}. {artist.name}
+                </li>
+              ))}
             </ol>
           </div>
-  
+
           {/* Top Tracks List */}
-          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-24">
-            <h3 className="text-xl font-semibold mb-4 text-center">Top Tracks</h3>
+          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
+            <h3 className="text-xl font-semibold mb-4">Top Tracks</h3>
             <ol className="space-y-2 text-gray-300">
-              <li>1. Track 1</li>
-              <li>2. Track 2</li>
-              <li>3. Track 3</li>
-              <li>4. Track 4</li>
-              <li>5. Track 5</li>
+              {topTracksCur.slice(0, 5).map((track, index) => (
+                <li key={track.id}>
+                  {index + 1}. {track.name}
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          {/* Top Albums List */}
+          <div className="bg-zinc-800 p-4 rounded-lg shadow-md w-1/2 mx-10">
+            <h3 className="text-xl font-semibold mb-4">Top Albums</h3>
+            <ol className="space-y-2 text-gray-300">
+              {topAlbumsCur.slice(0, 5).map((album, index) => (
+                <li key={album.id}>
+                  {index + 1}. {album.name}
+                </li>
+              ))}
             </ol>
           </div>
         </div>
+      </section>
+
+      {/* Genre Section */}
+      <section className="flex justify-center bg-zinc-800 py-6 px-8">
+        <hr></hr>
+        <h2 className="text-3xl font-bold text-center mb-8">
+          Genre Listening Trends
+        </h2>
       </section>
     </div>
   );

--- a/packages/react-frontend/src/utils/getTopUtils.js
+++ b/packages/react-frontend/src/utils/getTopUtils.js
@@ -1,4 +1,3 @@
-
 /*
 This file has three functions that give the top artists, tracks, and albums
 They each return a promise of a list of json objects
@@ -7,90 +6,110 @@ Use these functions to get the lists with all the data, then call the fields you
 for whatever you are working on
 */
 
+// function to delay for a specified number of milliseconds
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// retry mechanism for fetching (when rate limited)
+const fetchWithRetry = async (fetchFunction, retries = 3) => {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fetchFunction();
+    } catch (error) {
+      if (error.status === 429 && attempt < retries) {
+        // 429 = rate limited
+        const retryAfter = error.headers?.["Retry-After"]
+          ? parseInt(error.headers["Retry-After"], 10) * 1000
+          : 2 ** attempt * 1000; // exponential backoff
+        console.warn(`Rate limited. Retrying after ${retryAfter} ms...`);
+        await delay(retryAfter); // use the delay function to wait
+      } else {
+        console.error("Error fetching data:", error);
+        throw error; // if another error, rethrow
+      }
+    }
+  }
+};
+
 // Returns the top n artists, or as many as possible if the max is less than n
 function getTopNArtists(spotifyApi, maxArtists, timerange) {
-    let allArtists = [];
-    let offset = 0;
-    let limit = 50;
+  let allArtists = [];
+  let offset = 0;
+  let limit = 50;
 
-    // Function to get 50 artists at a time
-    const fetchBatchOfArtists = () => {
-        return spotifyApi.getMyTopArtists({ time_range: timerange, offset: offset, limit: limit })
-            .then((response) => {
-                allArtists = [...allArtists, ...response.items];
+  const fetchBatchOfArtists = async () => {
+    return spotifyApi
+      .getMyTopArtists({ time_range: timerange, offset, limit })
+      .then((response) => {
+        allArtists = [...allArtists, ...response.items];
 
-                if (allArtists.length >= maxArtists) { // Truncate list if we got too many artists
-                    allArtists = allArtists.slice(0, maxArtists); 
-                    return allArtists; 
-                }
+        if (allArtists.length >= maxArtists) {
+          allArtists = allArtists.slice(0, maxArtists);
+          return allArtists;
+        }
 
-                // Recursively get 50 more artists if needed
-                if (response.items.length === limit) {
-                    offset += limit;
-                    return fetchBatchOfArtists(); 
-                }
+        if (response.items.length === limit) {
+          offset += limit;
+          return fetchBatchOfArtists();
+        }
 
-                return allArtists; 
-            })
-            .catch((err) => {
-                console.error("Error fetching top artists:", err);
-                return []; 
-            });
-    };
+        return allArtists;
+      });
+  };
 
-    return fetchBatchOfArtists();
+  return fetchWithRetry(fetchBatchOfArtists);
 }
 
 // Returns the top n tracks, or as many as possible if the max is less than n
 function getTopNTracks(spotifyApi, maxTracks, timerange) {
-    let allTracks = [];
-    let offset = 0;
-    let limit = 50;
+  let allTracks = [];
+  let offset = 0;
+  let limit = 50;
 
-    const fetchBatchOfTracks = () => {
-        return spotifyApi.getMyTopTracks({ time_range: timerange, offset: offset, limit: limit })
-            .then((response) => {
-                allTracks = [...allTracks, ...response.items];
+  const fetchBatchOfTracks = async () => {
+    return spotifyApi
+      .getMyTopTracks({ time_range: timerange, offset, limit })
+      .then((response) => {
+        allTracks = [...allTracks, ...response.items];
 
-                if (allTracks.length >= maxTracks) {
-                    allTracks = allTracks.slice(0, maxTracks); 
-                    return allTracks;
-                }
+        if (allTracks.length >= maxTracks) {
+          allTracks = allTracks.slice(0, maxTracks);
+          return allTracks;
+        }
 
-                if (response.items.length === limit) {
-                    offset += limit;
-                    return fetchBatchOfTracks(); 
-                }
+        if (response.items.length === limit) {
+          offset += limit;
+          return fetchBatchOfTracks();
+        }
 
-                return allTracks; 
-            })
-            .catch((err) => {
-                console.error("Error fetching top artists:", err);
-                return []; 
-            });
-    };
-    
-    return fetchBatchOfTracks();
+        return allTracks;
+      });
+  };
+
+  return fetchWithRetry(fetchBatchOfTracks);
 }
 
 // Drawing from a list of tracks, calculate the top n albums
 async function getTopNAlbums(spotifyApi, maxAlbums, tracks) {
-    const trackIds = tracks.map((track) => track.album.id);
-    const idScores = trackIds.reduce((acc, id, index) => {
-        const score = trackIds.length - index;
-        if (acc[id]) {
-            acc[id] += score;
-        } else {
-            acc[id] = score;
-        }
-        return acc;
-    }, {});
+  const trackIds = tracks.map((track) => track.album.id);
+  const idScores = trackIds.reduce((acc, id, index) => {
+    const score = trackIds.length - index;
+    if (acc[id]) {
+      acc[id] += score;
+    } else {
+      acc[id] = score;
+    }
+    return acc;
+  }, {});
 
-    let sortedIds = Object.keys(idScores).sort((a, b) => idScores[b] - idScores[a]);
-    sortedIds = sortedIds.slice(0, maxAlbums);
-    const sortedAlbums = await Promise.all(sortedIds.map((id) => spotifyApi.getAlbum(id)));
+  let sortedIds = Object.keys(idScores).sort(
+    (a, b) => idScores[b] - idScores[a]
+  );
+  sortedIds = sortedIds.slice(0, maxAlbums);
+  const sortedAlbums = await Promise.all(
+    sortedIds.map((id) => spotifyApi.getAlbum(id))
+  );
 
-    return sortedAlbums;
+  return sortedAlbums;
 }
 
-export {getTopNArtists, getTopNTracks, getTopNAlbums};
+export { getTopNArtists, getTopNTracks, getTopNAlbums };


### PR DESCRIPTION
### Initial home page data integration

- Implemented real data for the top tracks, artists, and albums previews
- Overhauled front-end presentation of the page
- Implemented loading screen while all API calls are in progress
- Rewrote the helper utility function for getting top albums to improve efficiency and avoid rate limiting 
- Added link buttons to make the top tracks, artists, and album previews link to their respective pages
- Implemented Spotify Username and profile picture data for display
- Implemented genres graph visualization in the home page
- Added album grid image generator function and implemented into the home page introductory image